### PR TITLE
Have save overwrite existing files

### DIFF
--- a/dbfilestorage/storage.py
+++ b/dbfilestorage/storage.py
@@ -55,11 +55,17 @@ class DBFileStorage(Storage):
         ct = mimetypes.guess_type(name)[0]
 
         # create the file, or just return name if the exact file already exists
-        if not DBFile.objects.filter(name=name).exists():
-            the_file = DBFile.objects.create(
+        the_file = DBFile.objects.filter(name=name).first()
+        if not the_file:
+            DBFile.objects.create(
                 name=name,
                 content_type=ct,
                 b64=b64)
+        else:
+            the_file.content_type=ct
+            the_file.b64 = b64
+            the_file.save()
+
         return name
 
     def get_available_name(self, name, max_length=None):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ author = u'Tyrel Souza'
 # built documents.
 #
 # The short X.Y version.
-version = u'0.8.0'
+version = u'0.9.0'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class CleanCommand(Command):
 
 setup(
     name="django-dbfilestorage",
-    version="0.8.0",
+    version="0.9.0",
     description="Database backed file storage for testing.",
     long_description="Database backed file storage for testing. Stores files as base64 encoded textfields.",
     author="Tyrel Souza",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -77,6 +77,33 @@ class DBFileTest(TestCase):
         size = default_storage.size(self.filepath)
         self.assertGreater(size, 0)
 
+    def test_raw_save(self):
+        CONTENT_DATA_1 = u"Here's some stuff! ΑΔΔGΕΝΕ - ONE"
+        CONTENT_DATA_2 = u"Here's some stuff! ΑΔΔGΕΝΕ - TWO"
+        FILE_NAME = "saveable.txt"
+        self.assertFalse(DBFile.objects.filter(name=FILE_NAME).exists())
+
+        # -- Save to a _new_ file
+        content_file = ContentFile(CONTENT_DATA_1.encode("utf-8"))
+        default_storage.save(FILE_NAME, content_file)
+        self.assertTrue(DBFile.objects.filter(name=FILE_NAME).exists())
+
+        with default_storage.open(FILE_NAME, "rb") as f:
+            read_back = f.read().decode("utf-8")
+        self.assertEqual(read_back, CONTENT_DATA_1)
+
+        # -- Save to an _existing_ file
+        content_file = ContentFile(CONTENT_DATA_2.encode("utf-8"))
+        default_storage.save(FILE_NAME, content_file)
+        self.assertTrue(DBFile.objects.filter(name=FILE_NAME).exists())
+        with default_storage.open(FILE_NAME, "rb") as f:
+            read_back = f.read().decode("utf-8")
+        self.assertEqual(read_back, CONTENT_DATA_2)
+
+        # -- Clean up after ourselves
+        default_storage.delete(FILE_NAME)
+        self.assertFalse(DBFile.objects.filter(name=FILE_NAME).exists())
+
     def test_url(self):
         """ Test that the url returned is the filename """
         self.assertIn(self.filename, default_storage.url(self.filename))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -33,7 +33,7 @@ class DBFileTest(TestCase):
 
     def test_content_file(self):
         """ Test that this code works with ContentFile as well """
-        content_file = ContentFile(u"ΑΔΔGΕΝΕ")
+        content_file = ContentFile(u"ƊBStørage")
         default_storage.save("unicode", content_file)
         unicode_file = DBFile.objects.get(name="unicode")
         self.assertEqual(unicode(unicode_file),
@@ -78,8 +78,8 @@ class DBFileTest(TestCase):
         self.assertGreater(size, 0)
 
     def test_raw_save(self):
-        CONTENT_DATA_1 = u"Here's some stuff! ΑΔΔGΕΝΕ - ONE"
-        CONTENT_DATA_2 = u"Here's some stuff! ΑΔΔGΕΝΕ - TWO"
+        CONTENT_DATA_1 = u"Here's some stuff! ƊBStørage - ONE"
+        CONTENT_DATA_2 = u"Here's some stuff! ƊBStørage - TWO"
         FILE_NAME = "saveable.txt"
         self.assertFalse(DBFile.objects.filter(name=FILE_NAME).exists())
 


### PR DESCRIPTION
Currently, the `save` method only saves data to _new_ files and doesn't overwrite existing files.

This makes write and then read back operations impossible to test.

This PR will over-write the data for an existing file when save() is called.